### PR TITLE
Fix password hash in 7-security lecture

### DIFF
--- a/7-security/passwords/salt.go
+++ b/7-security/passwords/salt.go
@@ -14,7 +14,8 @@ func hashPass(salt []byte, plainPassword string) []byte {
 }
 
 func checkPass(passHash []byte, plainPassword string) bool {
-	salt := passHash[0:8]
+	salt := make([]byte, 8)
+	copy(salt, passHash[0:8])
 	userPassHash := hashPass(salt, plainPassword)
 	return bytes.Equal(userPassHash, passHash)
 }


### PR DESCRIPTION
При присваивании соли хеша пароля с помощью среза происходило присвоение по указателю, в результате чего  в функции hashPass при апенде к соли нового слайса менялся и наш passHash, что приводило к вечно-правильному паролю